### PR TITLE
Make all imports from react-icons external

### DIFF
--- a/tools/webpack.config.prod.js
+++ b/tools/webpack.config.prod.js
@@ -32,15 +32,14 @@ module.exports = {
     extensions: [ '.js', '.jsx' ]
   },
   // External dependencies don't need to be in our own dist
-  externals: {
-    'color': 'color',
-    'radium': 'radium',
-    'react': 'react',
-    'react-icons': 'react-icons',
-    'react-icon-base': 'react-icon-base',
-    'react-motion': 'react-motion',
-    'react-dimensions': 'react-dimensions',
-  },
+  externals: [
+    'color',
+    'radium',
+    'react',
+    /^react-icons\b/,
+    'react-motion',
+    'react-dimensions'
+  ],
   plugins: [
     new webpack.optimize.UglifyJsPlugin()
   ],


### PR DESCRIPTION
Fixes https://github.com/sherubthakur/react-horizontal-timeline/issues/27
- shrinks dist file from 18079 to 16738 bytes as `FaAngleLeft` and `FaAngleRight` are not bundled anymore
- dist file now contains `require("react-icons/lib/fa/angle-left")` and `require("react-icons/lib/fa/angle-right")` instead of `require("react-icon-base")`