### PR TITLE
Move react to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "color": "^2.0.0",
     "radium": "^0.19.1",
-    "react": "^15.0.2",
     "react-dimensions": "2.0.0-alpha1",
     "react-icons": "^2.0.1",
     "react-motion": "^0.5.0"
@@ -143,5 +142,8 @@
     "url-loader": "^0.5.7",
     "webpack": "^3.0.0",
     "webpack-dev-server": "^2.5.0"
+  },
+  "peerDependencies": {
+    "react": "^15.0.2"
   }
 }


### PR DESCRIPTION
Fixes problem with having two different versions of react installed by `yarn`.