### PR TITLE
Remove redundant call of indexClick

### DIFF
--- a/src/Components/TimelineDot.jsx
+++ b/src/Components/TimelineDot.jsx
@@ -105,7 +105,6 @@ class TimelineDot extends React.Component {
         { this.props.label }
         <span
           key='dot-dot'
-          onClick={() => this.props.onClick(this.props.index) }
           style={this.__getDotStyles__(dotType, this.props.date)}
         />
       </li>


### PR DESCRIPTION
Clicking on dot causes `indexClick` to be called twice - by `<li>` and by `<span>`. Is there a reason for it? 