### PR TITLE
propagate complete styles prop to buttonStyles

### DIFF
--- a/src/Components/HorizontalTimelineButtons.jsx
+++ b/src/Components/HorizontalTimelineButtons.jsx
@@ -20,7 +20,7 @@ import { FaAngleLeft, FaAngleRight } from 'react-icons/fa';
  * inactive: styles defined for when the icons are inactive.
  */
 const buttonStyles = {
-  link: ({ outline }) => ({
+  link: (styles) => ({
     position: 'absolute',
     top: '49px',
     bottom: 'auto',
@@ -28,11 +28,12 @@ const buttonStyles = {
     height: 34,
     width: 34,
     borderRadius: '50%',
-    border: `2px solid ${outline}`,
+    border: `2px solid ${styles.outline}`,
     overflow: 'hidden',
     textIndent: '100%',
     whiteSpace: 'nowrap',
     transition: 'border-color 0.3s',
+    ...styles.link
   }),
   icon: (styles, active) => ({
     position: 'absolute',
@@ -45,20 +46,23 @@ const buttonStyles = {
     overflow: 'hidden',
     textIndent: '100%',
     whiteSpace: 'nowrap',
-    fill: active ? styles.foreground : styles.outline
+    fill: active ? styles.foreground : styles.outline,
+    ...styles.icon
   }),
   inactive: (styles) => ({
     color: styles.outline,
     cursor: 'not-allowed',
     ':hover': {
       border: `2px solid ${styles.outline}`
-    }
+    },
+    ...styles.inactive
   }),
   active: (styles) => ({
     cursor: 'pointer',
     ':hover': {
       border: `2px solid ${styles.foreground}`,
-      color: styles.foreground
+      color: styles.foreground,
+      ...styles.active
     }
   })
 };


### PR DESCRIPTION
Hi all,
In our project we needed a bit more customization of the styles,

I don't know if this was previously proposed, but wouldn't it be nice to be able to pass any style property to the links, icons and dots on the timeline?

This can be achieved with one very simple change, as proposed in this fork/commit. I'm using the spread operator to replace any properties passed via the style property.

Best regards,
Goce